### PR TITLE
Fixes a casing issue in the drive mapping in the proxy.

### DIFF
--- a/cmd/container-desktop-proxy/main.go
+++ b/cmd/container-desktop-proxy/main.go
@@ -172,7 +172,7 @@ func rewriteBinds(jsonMap map[string]interface{}, path string) {
 						parts := strings.Split(s, ":")
 						if rt.GOOS == "windows" {
 							if parts[0] != "/" && len(parts[0]) == 1 {
-								s = path + "/" + parts[0]
+								s = path + "/" + strings.ToLower(parts[0])
 								s += strings.Join(parts[1:], ":")
 							}
 						} else if strings.HasPrefix(s, "/") {


### PR DESCRIPTION
## Summary of the Pull Request

Fixes an issue when a Windows path in a volume mapping contains an upper case drive letter it will silently fail.
The drive letter is converted to lower case now.