### PR TITLE
Made port forwarding optional. Added a setting to enable/disable.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "program": "${fileDirname}",
             "args":[
                 "--listen-address",
-                "http://localhost:5555",
+                "npipe:////./pipe/proxytest",
                 "--target-address",
                 "https://localhost:2376",
                 "--tls-key",

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ ARG DOCKER_VERSION="20.10.12"
 FROM docker:${DOCKER_VERSION}-dind
 COPY deployment/wsl.conf /etc/
 COPY deployment/wsl-init.sh /usr/local/bin/
-RUN mv /usr/local/bin/docker-proxy /usr/local/bin/docker-proxy-org
-COPY deployment/docker-proxy /usr/local/bin/
+RUN cp /usr/local/bin/docker-proxy /usr/local/bin/docker-proxy-org
+COPY deployment/docker-proxy /usr/local/bin/docker-proxy-shim
 COPY deployment/wsl-distro-*.sh /distro/
 RUN apk add netcat-openbsd
 COPY dist/docker/docker-compose /usr/local/bin/docker-compose

--- a/container-desktop/Common/Common.csproj
+++ b/container-desktop/Common/Common.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <RootNamespace>ContainerDesktop.Common</RootNamespace>
     <AssemblyName>ContainerDesktop.Common</AssemblyName>
+		<UseWPF>true</UseWPF>
   </PropertyGroup>
 
   <ItemGroup>

--- a/container-desktop/Common/IApplicationContext.cs
+++ b/container-desktop/Common/IApplicationContext.cs
@@ -1,4 +1,6 @@
-﻿namespace ContainerDesktop.Common;
+﻿using System.Windows;
+
+namespace ContainerDesktop.Common;
 
 public interface IApplicationContext
 {
@@ -8,4 +10,6 @@ public interface IApplicationContext
     void ShowMainWindow();
     void ShowSettings();
     void InvokeOnDispatcher(Action action);
+    T InvokeOnDispatcher<T>(Func<T> action);
+    Window MainWindow { get; }
 }

--- a/container-desktop/Common/IProductInformation.cs
+++ b/container-desktop/Common/IProductInformation.cs
@@ -12,6 +12,8 @@ public interface IProductInformation
     string ContainerDesktopDistroName { get; }
     string ContainerDesktopDataDistroName { get; }
     string ContainerDesktopAppDataDir { get; }
+    string ContainerDesktopDistroDir { get; }
+    string ContainerDesktopDataDistroDir { get; }
     string WebSiteUrl { get; }
     string Version { get; }
     string ReleasesFeed { get; }

--- a/container-desktop/Common/ProductInformation.cs
+++ b/container-desktop/Common/ProductInformation.cs
@@ -8,6 +8,8 @@ public class ProductInformation : IProductInformation
         ProxyPath = Path.Combine(InstallDir, "Resources", $"container-desktop-proxy-windows-amd64.exe");
         ProxyPath = Path.Combine(InstallDir, "Resources", $"container-desktop-port-forwarder.exe");
         ContainerDesktopAppDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), Name);
+        ContainerDesktopDataDistroDir = Path.Combine(ContainerDesktopAppDataDir, "wsl", "data-distro");
+        ContainerDesktopDistroDir = Path.Combine(ContainerDesktopAppDataDir, "wsl", "distro");
     }
 
     public string Name { get; } = "ContainerDesktop";
@@ -23,7 +25,9 @@ public class ProductInformation : IProductInformation
     public string ContainerDesktopAppDataDir { get; } 
     public string WebSiteUrl { get; } = "https://container-desktop.io";
     public string ReleasesFeed { get; } = "https://api.github.com/repos/container-desktop/container-desktop/releases";
-    
+    public string ContainerDesktopDistroDir { get; }
+    public string ContainerDesktopDataDistroDir { get; }
+
     private static string GetVersion()
     {
         var version = ThisAssembly.AssemblyInformationalVersion;

--- a/container-desktop/Configuration/ContainerDesktopConfiguration.cs
+++ b/container-desktop/Configuration/ContainerDesktopConfiguration.cs
@@ -41,6 +41,13 @@ public class ContainerDesktopConfiguration : ConfigurationObject, IContainerDesk
         set => SetValueAndNotify(value);
     }
 
+    [Display(Name = "Enable Port Forwarding", GroupName = ConfigurationGroups.Network, Description = "Enables port forwarding on external network interfaces.", Order = 2)]
+    public bool PortForwardingEnabled 
+    { 
+        get => GetValue<bool>(); 
+        set => SetValueAndNotify(value);
+    }
+
     [JsonIgnore]
     [Display(Name = "Automatically start at login", GroupName = ConfigurationGroups.Miscellaneous)]
     public bool AutoStart 

--- a/container-desktop/Configuration/IContainerDesktopConfiguration.cs
+++ b/container-desktop/Configuration/IContainerDesktopConfiguration.cs
@@ -10,4 +10,5 @@ public interface IContainerDesktopConfiguration : IConfigurationObject
     DnsMode DnsMode { get; set; }
     string? DnsAddresses { get; set; }
     bool AutoStart { get; set; }
+    bool PortForwardingEnabled { get; set; }
 }

--- a/container-desktop/ContainerDesktop/App.xaml.cs
+++ b/container-desktop/ContainerDesktop/App.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Windows;
+using System.Windows.Interop;
 
 public partial class App : ApplicationWithContext
 {
@@ -36,13 +37,14 @@ public partial class App : ApplicationWithContext
         MainViewModel = ServiceProvider.GetRequiredService<MainViewModel>();
         ContainerEngine = ServiceProvider.GetRequiredService<IContainerEngine>();
         var productInfo = ServiceProvider.GetRequiredService<IProductInformation>();
+        new WindowInteropHelper(MainWindow).EnsureHandle();
         MainViewModel.ShowTrayIcon = true;
         Task.Run(() => ContainerEngine.Start()).ToObservable().Subscribe(_ => { }, ex =>
         {
             Logger.LogError(ex, ex.Message);
             Dispatcher.Invoke(() =>
             {
-                MessageBox.Show($"{productInfo.DisplayName} failed to startup, please view the event log for errors.\r\n\r\nMessage:\r\n{ex.Message}", "Failed to start", MessageBoxButton.OK);
+                MessageBox.Show(MainWindow, $"{productInfo.DisplayName} failed to startup, please view the event log for errors.\r\n\r\nMessage:\r\n{ex.Message}", "Failed to start", MessageBoxButton.OK);
                 QuitApplication();
             });
         });
@@ -58,11 +60,4 @@ public partial class App : ApplicationWithContext
         var mainWindow = (MainWindow)MainWindow;
         mainWindow.ShowSettings();
     }
-
-    //public override void ShowMainWindow()
-    //{
-    //    base.ShowMainWindow();
-    //    var mainWindow = (MainWindow)MainWindow;
-    //    mainWindow.ShowMainPage();
-    //}
 }

--- a/container-desktop/ContainerDesktop/IDisposableProgress.cs
+++ b/container-desktop/ContainerDesktop/IDisposableProgress.cs
@@ -1,0 +1,5 @@
+﻿namespace ContainerDesktop;
+
+public interface IDisposableProgress : IProgress<string>, IDisposable
+{
+}

--- a/container-desktop/ContainerDesktop/MainWindow.xaml
+++ b/container-desktop/ContainerDesktop/MainWindow.xaml
@@ -49,6 +49,8 @@
                     <MenuItem Header="Settings" Command="{Binding OpenSettingsCommand}" />
                     <MenuItem Header="View log stream" Command="{Binding ViewLogStreamCommand}" />
                     <Separator/>
+                    <MenuItem Header="Reset" Command="{Binding ResetCommand}" />
+                    <Separator/>
                     <MenuItem Header="Quit Container Desktop" Command="{Binding QuitCommand}" />
                     <Separator />
                     <MenuItem Header="{Binding ProductInformation.Version}" Icon="{Binding UpdateAvailable, Converter={StaticResource UpdateIconConverter}, ConverterParameter=UpdateIcon}" ToolTip="{Binding UpdateAvailableTooltip}" Command="{Binding ShowLatestReleaseCommand}" HorizontalAlignment="{Binding UpdateAvailable, Converter={StaticResource UpdateAvailableAlignmentConverter}}" />

--- a/container-desktop/ContainerDesktop/MainWindow.xaml
+++ b/container-desktop/ContainerDesktop/MainWindow.xaml
@@ -32,7 +32,7 @@
                             </DataTemplate>
                         </MenuItem.ItemTemplate>
                     </MenuItem>
-                    <MenuItem Header="Port forwarding" ItemsSource="{Binding NetworkInterfaces}">
+                    <MenuItem Header="Port forwarding" ItemsSource="{Binding NetworkInterfaces}" Visibility="{Binding Configuration.PortForwardingEnabled, Converter={StaticResource BooleanToVisibilityConverter}}">
                         <MenuItem.ItemTemplate>
                             <DataTemplate>
                                 <MenuItem Header="{Binding Name}" IsCheckable="True" IsChecked="{Binding Forwarded, Mode=TwoWay}" IsEnabled="{Binding Enabled}" Command="{Binding RelativeSource={RelativeSource AncestorType={x:Type ContextMenu}}, Path=DataContext.CheckNetworkInterfaceCommand}" CommandParameter="{Binding .}"/>

--- a/container-desktop/ContainerDesktop/ProgressDialog.xaml
+++ b/container-desktop/ContainerDesktop/ProgressDialog.xaml
@@ -1,0 +1,17 @@
+﻿<Window x:Class="ContainerDesktop.ProgressDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:ContainerDesktop"
+        xmlns:ui="http://schemas.modernwpf.com/2019"
+        ui:WindowHelper.UseModernWindowStyle="True"
+        mc:Ignorable="d"
+        Title="Progress" Height="100" Width="250" WindowStartupLocation="CenterScreen" ResizeMode="NoResize" >
+    <Grid>
+        <StackPanel Orientation="Vertical" VerticalAlignment="Center" Margin="20 20">
+            <TextBlock x:Name="txtMessage" Text="Status" Margin="0 0 0 8"/>
+            <ProgressBar x:Name="progressBar" Minimum="0" Maximum="100" Height="4"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/container-desktop/ContainerDesktop/ProgressDialog.xaml.cs
+++ b/container-desktop/ContainerDesktop/ProgressDialog.xaml.cs
@@ -1,0 +1,58 @@
+﻿using System.ComponentModel;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace ContainerDesktop;
+
+/// <summary>
+/// Interaction logic for ProgressDialog.xaml
+/// </summary>
+public partial class ProgressDialog : Window
+{
+    public ProgressDialog()
+    {
+        InitializeComponent();
+    }
+
+    public static IDisposableProgress Show(string caption, int max)
+    {
+        var dlg = new ProgressDialog();
+        dlg.Title = caption;
+        dlg.txtMessage.Text = string.Empty;
+        dlg.progressBar.Minimum = 0;
+        dlg.progressBar.Maximum = max;
+        dlg.Show();
+        return new Progress(s => dlg.Dispatcher.Invoke(() =>
+        {
+            dlg.txtMessage.Text = s;
+            dlg.progressBar.Value += 1;
+        }), () => dlg.Dispatcher.Invoke(() => dlg.Close()));
+    }
+
+    protected override void OnClosing(CancelEventArgs e)
+    {
+        base.OnClosing(e);
+    }
+
+    private class Progress : IDisposableProgress
+    {
+        private readonly Action<string> _progress;
+        private readonly Action _close;
+
+        public Progress(Action<string> progress, Action close)
+        {
+            _progress = progress;
+            _close = close;
+        }
+
+        public void Dispose()
+        {
+            _close();
+        }
+
+        public void Report(string value)
+        {
+            _progress(value);
+        }
+    }
+}

--- a/container-desktop/ContainerDesktop/Services/DefaultContainerEngine.cs
+++ b/container-desktop/ContainerDesktop/Services/DefaultContainerEngine.cs
@@ -27,6 +27,7 @@ public sealed class DefaultContainerEngine : IContainerEngine, IDisposable
     private Task _dataDistroInitTask;
     private Task _portForwardListenerTask;
     private CancellationTokenSource _cts;
+    private CancellationTokenSource _portforwardListenerCts;
     private DnsConfigurator _dnsConfigurator;
 
     public DefaultContainerEngine(
@@ -44,6 +45,7 @@ public sealed class DefaultContainerEngine : IContainerEngine, IDisposable
         // TODO: query the state
         _runningState = RunningState.Stopped;
         LocalCertsPath = Path.Combine(_productInformation.ContainerDesktopAppDataDir, "certs\\");
+        ConfigurationChangedEventManager.AddHandler(_configurationService, OnConfigurationChanged);
     }
 
     public event EventHandler RunningStateChanged;
@@ -78,24 +80,44 @@ public sealed class DefaultContainerEngine : IContainerEngine, IDisposable
 
     private void InitializePortForwardListener()
     {
-        _portForwardListenerTask = Task.Run(async () =>
+        if (_configurationService.Configuration.PortForwardingEnabled)
         {
-            while (!_cts.IsCancellationRequested)
+            _portforwardListenerCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
+            if(!_wslService.ExecuteCommand("cp /usr/local/bin/docker-proxy-shim /usr/local/bin/docker-proxy", _productInformation.ContainerDesktopDistroName, stdout: s => _logger.LogInformation(s)))
             {
-                _logger.LogInformation("Listening for port forward messages.");
-                await _wslService.ExecuteCommandAsync(
-                    "nc -lk -U /var/run/cd-port-forward.sock", 
-                    _productInformation.ContainerDesktopDistroName,
-                    stdout: ForwardPort,
-                    cancellationToken: _cts.Token);
-                if (!_cts.IsCancellationRequested)
-                {
-                    _logger.LogWarning("Listening for port forward messages stopped unexpectedly, trying to restart.");
-                    await Task.Delay(100);
-                }
+                _logger.LogError("Could not initialize port forwarding.");
+                return;
             }
-            _logger.LogInformation("Stopped listening for port forward messages.");
-        });
+            _portForwardListenerTask = Task.Run(async () =>
+            {
+                try
+                {
+                    while (!_portforwardListenerCts.IsCancellationRequested)
+                    {
+                        _logger.LogInformation("Listening for port forward messages.");
+                        await _wslService.ExecuteCommandAsync(
+                            "nc -lk -U /var/run/cd-port-forward.sock",
+                            _productInformation.ContainerDesktopDistroName,
+                            stdout: ForwardPort,
+                            cancellationToken: _portforwardListenerCts.Token);
+                        if (!_portforwardListenerCts.IsCancellationRequested)
+                        {
+                            _logger.LogWarning("Listening for port forward messages stopped unexpectedly, trying to restart.");
+                            await Task.Delay(100);
+                        }
+                    }
+                    _logger.LogInformation("Stopped listening for port forward messages.");
+                }
+                catch(TaskCanceledException)
+                {
+                    _logger.LogInformation("Stopped listening for port forward messages.");
+                }
+            });
+        }
+        else
+        {
+            _portForwardListenerTask = Task.CompletedTask;
+        }
     }
 
     private static readonly Regex _hostipParser = new(@"-host-ip (?'h'::|0\.0\.0\.0)", RegexOptions.Singleline | RegexOptions.Compiled);
@@ -257,6 +279,7 @@ public sealed class DefaultContainerEngine : IContainerEngine, IDisposable
         try
         {
             Stop();
+            ConfigurationChangedEventManager.RemoveHandler(_configurationService, OnConfigurationChanged);
         }
         finally
         {
@@ -395,6 +418,38 @@ public sealed class DefaultContainerEngine : IContainerEngine, IDisposable
                 {
                     _logger.LogError(ex, "Failed to forward port on {Address}:{Port}: {Message}", address.ToString(), port, ex.Message);
                 }
+            }
+        }
+    }
+
+    private async void OnConfigurationChanged(object sender, ConfigurationChangedEventArgs e)
+    {
+        if (RunningState == RunningState.Started && e.PropertiesChanged.Contains(nameof(IContainerDesktopConfiguration.PortForwardingEnabled)))
+        {
+            try
+            {
+                if (_configurationService.Configuration.PortForwardingEnabled)
+                {
+                    _logger.LogInformation($"{nameof(IContainerDesktopConfiguration.PortForwardingEnabled)} setting changed to true, trying to initialize port forwarding");
+                    InitializePortForwardListener();
+                }
+                else
+                {
+                    _logger.LogInformation($"{nameof(IContainerDesktopConfiguration.PortForwardingEnabled)} setting changed to false, trying to stop port forwarding");
+                    if (_portforwardListenerCts != null)
+                    {
+                        _portforwardListenerCts.Cancel();
+                        await _portForwardListenerTask;
+                    }
+                    if(!_wslService.ExecuteCommand("cp /usr/local/bin/docker-proxy-org /usr/local/bin/docker-proxy", _productInformation.ContainerDesktopDistroName, stdout: s => _logger.LogInformation(s)))
+                    {
+                        _logger.LogError("Could not disable port forwarding");
+                    }
+                }
+            }
+            catch(Exception ex)
+            {
+                _logger.LogError(ex, $"Failed to change the {nameof(IContainerDesktopConfiguration.PortForwardingEnabled)} setting.");
             }
         }
     }

--- a/container-desktop/ContainerDesktop/ViewModels/MainViewModel.cs
+++ b/container-desktop/ContainerDesktop/ViewModels/MainViewModel.cs
@@ -75,6 +75,8 @@ public class MainViewModel : NotifyObject
         Task.Run(() => CheckForUpdateAsync());
     }
 
+    public IContainerDesktopConfiguration Configuration => _configurationService.Configuration;
+
     public IProductInformation ProductInformation { get; }
 
     public bool ShowTrayIcon

--- a/container-desktop/ContainerDesktop/ViewModels/MainViewModel.cs
+++ b/container-desktop/ContainerDesktop/ViewModels/MainViewModel.cs
@@ -10,6 +10,7 @@ using ContainerDesktop.UI.Wpf.Input;
 using ContainerDesktop.Wsl;
 using NuGet.Versioning;
 using System.Diagnostics;
+using System.IO.Abstractions;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Net.NetworkInformation;
@@ -29,6 +30,7 @@ public class MainViewModel : NotifyObject
     private readonly IConfigurationService _configurationService;
     private readonly IProcessExecutor _processExecutor;
     private readonly ILogger<MainViewModel> _logger;
+    private readonly IFileSystem _fileSystem;
     private bool _showTrayIcon;
     private bool _isStarted;
     private BitmapImage _trayIcon = _icon; // "/ContainerDesktop;component/app.ico";
@@ -44,6 +46,7 @@ public class MainViewModel : NotifyObject
         IConfigurationService configurationService,
         IProcessExecutor processExecutor,
         IProductInformation productInformation,
+        IFileSystem fileSystem,
         ILogger<MainViewModel> logger)
     {
         _applicationContext = applicationContext;
@@ -53,6 +56,7 @@ public class MainViewModel : NotifyObject
         _configurationService = configurationService;
         _processExecutor = processExecutor;
         ProductInformation = productInformation;
+        _fileSystem = fileSystem;
         _logger = logger;
         OpenCommand = new DelegateCommand(Open);
         QuitCommand = new DelegateCommand(Quit);
@@ -65,6 +69,7 @@ public class MainViewModel : NotifyObject
         CheckNetworkInterfaceCommand = new DelegateCommand<PortForwardInterface>(TogglePortForwardInterface);
         OpenSettingsCommand = new DelegateCommand(OpenSettings);
         ShowLatestReleaseCommand = new DelegateCommand(ShowLatestRelease, () => UpdateAvailable);
+        ResetCommand = new DelegateCommand(Reset, () => _containerEngine.RunningState != RunningState.Starting);
 
         var menuItems = new List<IMenuItem>
         {
@@ -126,6 +131,8 @@ public class MainViewModel : NotifyObject
     public DelegateCommand ShowLatestReleaseCommand { get; }
 
     public DelegateCommand<PortForwardInterface> CheckNetworkInterfaceCommand { get; }
+
+    public DelegateCommand ResetCommand { get; }
 
     public IEnumerable<WslDistributionItem> WslDistributions =>
         _wslService.GetDistros()
@@ -197,6 +204,7 @@ public class MainViewModel : NotifyObject
             StartCommand.RaiseCanExecuteChanged();
             StopCommand.RaiseCanExecuteChanged();
             RestartCommand.RaiseCanExecuteChanged();
+            ResetCommand.RaiseCanExecuteChanged();
             TrayIcon = _containerEngine.RunningState switch
             {
                 RunningState.Started => _runIcon,
@@ -296,7 +304,7 @@ public class MainViewModel : NotifyObject
         catch (Exception ex)
         {
             _applicationContext.InvokeOnDispatcher(() =>
-                MessageBox.Show(ex.Message, $"Failed to {caption}", MessageBoxButton.OK));
+                MessageBox.Show(_applicationContext.MainWindow, ex.Message, $"Failed to {caption}", MessageBoxButton.OK, MessageBoxImage.Error));
         }
     }
 
@@ -320,6 +328,51 @@ public class MainViewModel : NotifyObject
         catch(Exception ex)
         {
             _logger.LogError(ex, "Could not retrieve a list of releases.");
+        }
+    }
+
+    private async void Reset()
+    {
+        if(MessageBox.Show(_applicationContext.MainWindow, $"This will reinstall the {ProductInformation.DisplayName} WSL2 distributions. This will remove all data. \r\nDo you want to continue ?", "Reset", MessageBoxButton.YesNo, MessageBoxImage.Warning) != MessageBoxResult.Yes)
+        {
+            return;
+        }
+        await Task.Run(() =>
+        {
+            SafeExecute("Reset", () =>
+            {
+                using (var dlg = _applicationContext.InvokeOnDispatcher(() => ProgressDialog.Show("Reset", 5)))
+                {
+                    LogAndProgress(dlg, "Stopping");
+                    _containerEngine.Stop();
+                    LogAndProgress(dlg, "Unregistering distributions");
+                    _wslService.Unregister(ProductInformation.ContainerDesktopDistroName);
+                    _wslService.Unregister(ProductInformation.ContainerDesktopDataDistroName);
+                    LogAndProgress(dlg, "Deleting distribution folders");
+                    _fileSystem.Directory.Delete(ProductInformation.ContainerDesktopDistroDir, true);
+                    _fileSystem.Directory.Delete(ProductInformation.ContainerDesktopDataDistroDir, true);
+                    LogAndProgress(dlg, "Importing distributions");
+                    _fileSystem.Directory.CreateDirectory(ProductInformation.ContainerDesktopDistroDir);
+                    _fileSystem.Directory.CreateDirectory(ProductInformation.ContainerDesktopDataDistroDir);
+                    if (!_wslService.Import(ProductInformation.ContainerDesktopDistroName, ProductInformation.ContainerDesktopDistroDir, Path.Combine(ProductInformation.InstallDir, "Resources", "container-desktop-distro.tar.gz")))
+                    {
+                        throw new ContainerEngineException("Could not import distribution.");
+                    }
+                    if (!_wslService.Import(ProductInformation.ContainerDesktopDataDistroName, ProductInformation.ContainerDesktopDataDistroDir, Path.Combine(ProductInformation.InstallDir, "Resources", "container-desktop-data-distro.tar.gz")))
+                    {
+                        throw new ContainerEngineException("Could not import data distribution.");
+                    }
+                    LogAndProgress(dlg, "Starting");
+                    _containerEngine.Start();
+                }
+                _applicationContext.InvokeOnDispatcher(() => MessageBox.Show(_applicationContext.MainWindow, $"Successfully reset {ProductInformation.DisplayName}.", "Reset"));
+            });
+        });
+
+        void LogAndProgress(IProgress<string> progress, string msg)
+        {
+            _logger.LogInformation(msg);
+            progress?.Report(msg);
         }
     }
 

--- a/container-desktop/Wpf/ApplicationWithContext.cs
+++ b/container-desktop/Wpf/ApplicationWithContext.cs
@@ -35,4 +35,9 @@ public class ApplicationWithContext : Application, IApplicationContext
     {
         Dispatcher.Invoke(action);
     }
+
+    public T InvokeOnDispatcher<T>(Func<T> action)
+    {
+        return Dispatcher.Invoke<T>(action);
+    }
 }

--- a/container-desktop/container-desktop.sln
+++ b/container-desktop/container-desktop.sln
@@ -27,7 +27,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Wsl", "Wsl\Wsl.csproj", "{9
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Abstractions", "Abstractions\Abstractions.csproj", "{8F55F175-0454-4C16-A70B-CC95CEF811DD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Configuration", "Configuration\Configuration.csproj", "{FA8A4562-3005-4906-8673-81C38B9A54AA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Configuration", "Configuration\Configuration.csproj", "{FA8A4562-3005-4906-8673-81C38B9A54AA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -67,8 +67,8 @@ Global
 		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|Any CPU.ActiveCfg = Release|x86
 		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|arm64.ActiveCfg = Release|arm64
 		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|arm64.Build.0 = Release|arm64
-		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|x64.ActiveCfg = Release|x64
-		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|x64.Build.0 = Release|x64
+		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|x64.ActiveCfg = Release|Any CPU
+		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|x64.Build.0 = Release|Any CPU
 		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|x86.ActiveCfg = Release|x86
 		{6B190400-010A-4100-A97A-314B05D25F1A}.Release|x86.Build.0 = Release|x86
 		{00816323-9F10-4065-8913-C268028FEAD7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/deployment/wsl-init.sh
+++ b/deployment/wsl-init.sh
@@ -11,6 +11,10 @@ mount --bind /proxy /mnt/host/wsl/container-desktop/proxy
 mount --bind /distro /mnt/host/wsl/container-desktop/distro
 mount --bind /mnt/host/wsl /mnt/wsl
 mount --bind /mnt/host/wsl/container-desktop-data/data /var/lib/docker
+mkdir -p /sys/fs/cgroup/systemd
+if ! mountpoint -q /sys/fs/cgroup/systemd; then
+  mount -t cgroup -o none,name=systemd cgroup /sys/fs/cgroup/systemd
+fi
 export DOCKER_TLS_CERTDIR=/certs
 nohup /usr/local/bin/dockerd-entrypoint.sh >/dev/null 2>&1 &
 c=0

--- a/internal/httputil/closewriter.go
+++ b/internal/httputil/closewriter.go
@@ -3,3 +3,7 @@ package httputil
 type CloseWriter interface {
 	CloseWrite() error
 }
+
+type CloseReader interface {
+	CloseRead() error
+}

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0.0",
-  "versionHeightOffset": -1,
+  "version": "1.0",
+  "versionHeightOffset": 0,
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/tags/v\\d+.\\d+.\\d+"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

* Made port forwarding feature optional. It seems not stable enough at the moment
* Added a setting to the settings page to enable/disable port forwarding
* Fixed issue in the proxy when forwarding stdin which is closed by the user
* Fixed issue with Kind
* Added Reset option to the context menu. When for some reason Container Desktop is in a corrupted state and Restart doensn't help, you can now do a Reset that will restore the distributions. You will loose your data but Container Desktop will run again

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

### Port forwarding

When disabled docker-proxy is not replaced.

### Proxy

When forwarding stdin, e.g. `docker exec -i somecontainer cp /dev/stdin /somefile`, the tcp stream is closed by the client. In this case the backend doesn't know about this because we hadn't access to the underlying connection to the backend to do a CloseWrite. This is solved by using a httptrace.ClientTrace to catch the underlying connection and do a CloseWrite if the connection supports it. Now the backend will also close and the client will not hang.

### Distro

Kind needs cgroup mounted on /sys/fs/cgroup/systemd. So we now mount this when starting the distro.

[x] Closes #40 