### PR TITLE
Added docker plugins for linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Download and extract docker cli
         run: docker run --rm -v $PWD:/src container-desktop-tools:build sh -c "curl -LO https://download.docker.com/win/static/stable/x86_64/docker-$DOCKER_VERSION.zip && unzip -o docker-$DOCKER_VERSION.zip -x docker/dockerd.exe -d /src/dist"
       
+      - name: Extract Linux docker cli and plugins 
+        run: docker run --rm -v $PWD:/src container-desktop-tools:build sh -c "mkdir /src/dist/docker/linux && cp -R /usr/libexec/docker/cli-plugins /src/dist/docker/linux"
+
       - name: Download docker compose
         run: |
           docker run --rm -v $PWD:/src container-desktop-tools:build sh -c "curl -L -o /src/dist/docker/docker-compose.exe https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-Windows-x86_64.exe"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,17 @@ COPY deployment/docker-proxy /usr/local/bin/docker-proxy-shim
 COPY deployment/wsl-distro-*.sh /distro/
 RUN apk add netcat-openbsd
 COPY dist/docker/docker-compose /usr/local/bin/docker-compose
+COPY dist/docker/linux/cli-plugins /usr/libexec/docker/cli-plugins/
+COPY dist/docker/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
 RUN chmod +x /usr/local/bin/wsl-init.sh && \
     chmod +x /distro/wsl-distro-init.sh && \
     chmod +x /distro/wsl-distro-rm.sh && \
     chmod +x /usr/local/bin/docker-proxy && \
-    chmod +x /usr/local/bin/docker-compose
-RUN mkdir -p /usr/local/bin/cli-tools && \
+    chmod +x /usr/local/bin/docker-compose && \
+    find /usr/libexec/docker/cli-plugins -type f -exec chmod +x {} \;
+RUN mkdir -p /usr/local/bin/cli-tools/cli-plugins && \
     ln /usr/local/bin/docker /usr/local/bin/cli-tools/docker && \
-    ln /usr/local/bin/docker-compose /usr/local/bin/cli-tools/docker-compose
+    ln /usr/local/bin/docker-compose /usr/local/bin/cli-tools/docker-compose && \
+    find /usr/libexec/docker/cli-plugins -type f -exec sh -c 'ln {} /usr/local/bin/cli-tools/cli-plugins/$(basename {})' \;
 COPY dist/container-desktop-proxy-linux-amd64 /proxy/container-desktop-proxy
 RUN chmod +x /proxy/container-desktop-proxy

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
 # This script is dependent on:
-# - dotnet 5.0 SDK
+# - dotnet 6.0 SDK
 # - docker
 # This script must run on Windows because the application is a Windows application.
 $DOCKER_VERSION="20.10.12"
@@ -18,6 +18,8 @@ dotnet clean .\container-desktop\container-desktop.sln
 docker build -t container-desktop-tools:build --build-arg "DOCKER_VERSION=$DOCKER_VERSION" tools/container-desktop-tools/
 # Download and extract docker cli to /dist/docker
 docker run --rm -v "$($PWD):/src" container-desktop-tools:build sh -c "curl -LO https://download.docker.com/win/static/stable/x86_64/docker-$DOCKER_VERSION.zip && unzip -o docker-$DOCKER_VERSION.zip -x docker/dockerd.exe -d /src/dist"
+# Extract Linux docker cli and plugins 
+docker run --rm -v "$($PWD):/src" container-desktop-tools:build sh -c "mkdir /src/dist/docker/linux && cp -R /usr/libexec/docker/cli-plugins /src/dist/docker/linux"
 # Download docker-compose to /dist/docker
 docker run --rm -v "$($PWD):/src" container-desktop-tools:build sh -c "curl -L -o /src/dist/docker/docker-compose.exe https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-Windows-x86_64.exe"
 docker run --rm -v "$($PWD):/src" container-desktop-tools:build sh -c "curl -L -o /src/dist/docker/docker-compose https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-linux-x86_64"

--- a/deployment/wsl-distro-init.sh
+++ b/deployment/wsl-distro-init.sh
@@ -2,8 +2,13 @@
 distro="${1:-$WSL_DISTRO_NAME}"
 mkdir -p /mnt/wsl/$distro
 mount --bind / /mnt/wsl/$distro
+mkdir -p /usr/libexec/docker
+if [ -d /usr/libexec/docker/cli-plugins ]; then
+  rm -rf /usr/libexec/docker/cli-plugins
+fi
 readlink /usr/local/bin/docker || ln -s /mnt/wsl/container-desktop/cli-tools/docker /usr/local/bin/docker
 readlink /usr/local/bin/docker-compose || ln -s /mnt/wsl/container-desktop/cli-tools/docker-compose /usr/local/bin/docker-compose
+readlink /usr/libexec/docker/cli-plugins || ln -s /mnt/wsl/container-desktop/cli-tools/cli-plugins /usr/libexec/docker/cli-plugins
 rm /var/run/docker.sock
 /mnt/wsl/container-desktop/proxy/container-desktop-proxy \
   --listen-address unix:///var/run/docker.sock \

--- a/deployment/wsl-distro-rm.sh
+++ b/deployment/wsl-distro-rm.sh
@@ -3,5 +3,6 @@ distro="${1:-$WSL_DISTRO_NAME}"
 pkill -f container-desktop-proxy
 readlink /usr/local/bin/docker-compose && unlink /usr/local/bin/docker-compose
 readlink /usr/local/bin/docker && unlink /usr/local/bin/docker
+readlink /usr/libexec/docker/cli-plugins && unlink /usr/libexec/docker/cli-plugins
 #umount /mnt/wsl/$distro
 #rmdir /mnt/wsl/$distro

--- a/tools/container-desktop-tools/Dockerfile
+++ b/tools/container-desktop-tools/Dockerfile
@@ -1,4 +1,7 @@
-ARG DOCKER_VERSION="20.10.8" 
-FROM docker:20.10.8
-RUN apk update && \
-    apk add curl unzip zip
+ARG DOCKER_VERSION="20.10.12"
+FROM ubuntu
+RUN apt-get update -y && apt-get install -y ca-certificates curl gnupg lsb-release unzip zip
+RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN apt-get update -y && apt-get install -y docker-ce-cli


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Added docker plugins like docker-compose, docker-buildx etc in the correct location when using the WSL integration feature.

<!-- Please review the items on the PR checklist before submitting-->
## Pull Request Checklist

* [x] Closes #44 

<!-- Provide a more detailed description of the PR, other things fixed or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

Until now we only shipped the docker executable and linked it in another WSL distro. Today docker ships with plugins line docker-compose and docker-buildx. Now we included these plugins and link them in the /usr/libexec/docker/cli-plugins directory.
On Windows this is not needed because the plugins are part of docker.exe itself.