### PR TITLE
Copy Windows dockker plugins to the right location

### DIFF
--- a/container-desktop/DesiredStateConfiguration/DesiredStateConfiguration.csproj
+++ b/container-desktop/DesiredStateConfiguration/DesiredStateConfiguration.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Dism" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="PInvoke.AdvApi32" Version="0.7.104" />

--- a/container-desktop/Installer/Resources/configuration-manifest.json
+++ b/container-desktop/Installer/Resources/configuration-manifest.json
@@ -75,6 +75,37 @@
     },
     {
       "type": "CreateDirectory",
+      "id": "CreateProgramDataDockerCliPluginsFolder",
+      "decription": "Create cli plugin folder",
+      "directory": "%PROGRAMDATA%\\Docker\\cli-plugins",
+      "noUninstall": true
+    },
+    {
+      "type": "CopyFile",
+      "id": "CopyCliPluginDockerApp",
+      "description": "Copy docker app plugin",
+      "source": "%INSTALLDIR%\\cli\\cli-plugins\\docker-app.exe",
+      "target": "%PROGRAMDATA%\\Docker\\cli-plugins\\docker-app.exe",
+      "noUninstall": true
+    },
+    {
+      "type": "CopyFile",
+      "id": "CopyCliPluginDockerBuildx",
+      "description": "Copy docker buildx plugin",
+      "source": "%INSTALLDIR%\\cli\\cli-plugins\\docker-buildx.exe",
+      "target": "%PROGRAMDATA%\\Docker\\cli-plugins\\docker-buildx.exe",
+      "noUninstall": true
+    },
+    {
+      "type": "CopyFile",
+      "id": "CopyCliPluginDockerDockerCompose",
+      "description": "Copy docker compose plugin",
+      "source": "%INSTALLDIR%\\cli\\docker-compose.exe",
+      "target": "%PROGRAMDATA%\\Docker\\cli-plugins\\docker-compose.exe",
+      "noUninstall": true
+    },
+    {
+      "type": "CreateDirectory",
       "id": "CreateAppDataDirectory",
       "description": "Creating Application data directory",
       "directory": "%LOCALAPPDATA%\\%PRODUCT_NAME%"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

On Windows the plugins are also separate executables that need to be installed in c:\ProgramData\Docker\cli-plugins.
The installer will now copy the plugins in that location.

<!-- Please review the items on the PR checklist before submitting-->
## Pull Request Checklist

* [x] Closes #47