### PR TITLE
Create directory if not exists

### DIFF
--- a/container-desktop/Installer/ViewModels/MainViewModel.cs
+++ b/container-desktop/Installer/ViewModels/MainViewModel.cs
@@ -80,6 +80,10 @@ public class MainViewModel : NotifyObject, IUserInteraction
     private void SaveOptionalResources()
     {
         var optionsFileName = Path.Combine(ProductInformation.ContainerDesktopAppDataDir, "installer-optionals.json");
+        if(!_fileSystem.Directory.Exists(ProductInformation.ContainerDesktopAppDataDir))
+        {
+            _fileSystem.Directory.CreateDirectory(ProductInformation.ContainerDesktopAppDataDir);
+        }
         var optionals = OptionalResources.Where(x => x.Enabled).Select(x => x.Id).ToList();
         var json = JsonConvert.SerializeObject(optionals);
         _fileSystem.File.WriteAllText(optionsFileName, json);


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

Fix an exception on fresh install when the local app data folder does not exist yet. Folder is now created when it doesn't exist.

<!-- Please review the items on the PR checklist before submitting-->
## Pull Request Checklist

* [x] Closes #58 