### PR TITLE
Added dns forwarder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,16 @@ RUN apk add netcat-openbsd
 COPY dist/docker/docker-compose /usr/local/bin/docker-compose
 COPY dist/docker/linux/cli-plugins /usr/libexec/docker/cli-plugins/
 COPY dist/docker/docker-compose /usr/libexec/docker/cli-plugins/docker-compose
+ADD https://github.com/janeczku/go-dnsmasq/releases/download/1.0.7/go-dnsmasq-min_linux-amd64 /usr/local/bin/dns-forwarder
 RUN chmod +x /usr/local/bin/wsl-init.sh && \
     chmod +x /distro/wsl-distro-init.sh && \
     chmod +x /distro/wsl-distro-rm.sh && \
     chmod +x /usr/local/bin/docker-proxy && \
     chmod +x /usr/local/bin/docker-compose && \
+    chmod +x /usr/local/bin/dns-forwarder && \
     find /usr/libexec/docker/cli-plugins -type f -exec chmod +x {} \;
 RUN mkdir -p /usr/local/bin/cli-tools/cli-plugins && \
+    mkdir -p /etc/docker && \
     ln /usr/local/bin/docker /usr/local/bin/cli-tools/docker && \
     ln /usr/local/bin/docker-compose /usr/local/bin/cli-tools/docker-compose && \
     find /usr/libexec/docker/cli-plugins -type f -exec sh -c 'ln {} /usr/local/bin/cli-tools/cli-plugins/$(basename {})' \;

--- a/README.md
+++ b/README.md
@@ -79,9 +79,8 @@ Container Desktop is made possible by using the following great projects:
 * [Reactive Extensions](https://github.com/dotnet/reactive)
 * [CompareNetObject](https://github.com/GregFinzer/Compare-Net-Objects)
 * [AvalonEdit](https://github.com/icsharpcode/AvalonEdit)
-* [INI File Parser](https://github.com/rickyah/ini-parser])
 * [NuGet.Versioning](https://github.com/NuGet/Home)
 * [Docker CLI](https://github.com/docker/cli)
 * [Docker Compose CLI](https://github.com/docker/compose-cli)
 * [The Moby Project](https://github.com/moby/moby)
-
+* [go-dnsmasq](https://github.com/janeczku/go-dnsmasq)

--- a/container-desktop/ContainerDesktop/ContainerDesktop.csproj
+++ b/container-desktop/ContainerDesktop/ContainerDesktop.csproj
@@ -32,7 +32,6 @@
     <PackageReference Include="CompareNETObjects" Version="4.74.0" />
     <PackageReference Include="Docker.DotNet" Version="3.125.5" />
     <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="1.1.0" />
-    <PackageReference Include="ini-parser-netstandard" Version="2.5.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.0" />

--- a/deployment/wsl.conf
+++ b/deployment/wsl.conf
@@ -1,3 +1,6 @@
 [automount]
 root = /mnt/host
 options = "metadata"
+
+[network]
+generateResolvConf = false


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When using WSL or the primary adapter as DNS server, resolving addresses might fail inside a cointainer when WSL is restarted or your primary adapter changes. When a docker container starts, docker copies the resolv.conf to the container if the container is not attached to a docker network. If the DNS server in the container desktop changes, these changes are not reflected in the container.
To solve this we run a dns-forwarder inside the distribution and configure resolv.conf to the ip address of the distribution. This way we can change the forwarder and containers always point to the forwarder.

<!-- Please review the items on the PR checklist before submitting-->
## Pull Request Checklist

* Closes #62 
