### PR TITLE
added quotes around path that may contain spaces

### DIFF
--- a/container-desktop/ContainerDesktop/Services/DefaultContainerEngine.cs
+++ b/container-desktop/ContainerDesktop/Services/DefaultContainerEngine.cs
@@ -443,9 +443,9 @@ public sealed class DefaultContainerEngine : IContainerEngine, IDisposable
         var args = new ArgumentBuilder()
             .Add("--listen-address", "npipe:////./pipe/docker_engine")
             .Add("--target-address", "https://localhost:2376")
-            .Add("--tls-key", Path.Combine(LocalCertsPath, "key.pem"))
-            .Add("--tls-cert", Path.Combine(LocalCertsPath, "cert.pem"))
-            .Add("--tls-ca", Path.Combine(LocalCertsPath, "ca.pem"))
+            .Add("--tls-key", Path.Combine(LocalCertsPath, "key.pem"), true)
+            .Add("--tls-cert", Path.Combine(LocalCertsPath, "cert.pem"), true)
+            .Add("--tls-ca", Path.Combine(LocalCertsPath, "ca.pem"), true)
             .Build();
         _proxyProcess = _processExecutor.Start(proxyPath, args);
         // Give it some time to startup

--- a/deployment/wsl-init.sh
+++ b/deployment/wsl-init.sh
@@ -26,5 +26,5 @@ while [ ! -S /var/run/docker.sock ]; do
     fi
 done
 echo "Docker daemon started."
-mkdir -p $1
-cp /certs/client/*.pem $1
+mkdir -p "$1"
+cp /certs/client/*.pem "$1"


### PR DESCRIPTION
<!-- Enter a brief description/summary of your PR here. What does it fix/what does it change/how was it tested (even manually, if necessary)? -->
## Summary of the Pull Request

When the user folder on Windows contains spaces, container desktop fails to start because paths are not correctly quoted.

<!-- Please review the items on the PR checklist before submitting-->
## Pull Request Checklist

* [x] Closes #68 